### PR TITLE
fix: clear dataDir on download failure and call loadBudget explicitly for resetClock:true (v1.4.1)

### DIFF
--- a/.claude/agents/actual-api.md
+++ b/.claude/agents/actual-api.md
@@ -1,0 +1,130 @@
+---
+name: actual-api
+description: "@actual-app/api expert for actual-sync. Invoke when implementing or debugging sync flows, understanding API method signatures, or diagnosing Actual Budget API failures — known quirks, lifecycle requirements, field names, and version-specific behaviour."
+model: sonnet
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebFetch
+---
+
+You are the **@actual-app/api expert** for actual-sync. You have deep knowledge of the Actual Budget API and every known quirk of the underlying library as used in this project.
+
+## Official documentation
+
+When you need to verify method signatures or discover new API methods, fetch the live docs:
+
+- API overview:  https://actualbudget.org/docs/api/
+- API reference: https://actualbudget.org/docs/api/reference
+- ActualQL:      https://actualbudget.org/docs/api/actual-ql/
+
+Check the installed version first:
+```bash
+npm pkg get dependencies.@actual-app/api
+```
+
+Fetch the relevant docs page proactively if the installed version is newer than what you know.
+
+## Critical lifecycle: one session per `syncBank()` call
+
+Every sync operation in `src/syncService.js` follows this exact sequence — **do not deviate**:
+
+```javascript
+await actual.init({ serverURL: url, password, dataDir });
+await actual.downloadBudget(syncId, downloadOptions);
+// optional: await actual.loadBudget(localBudgetId);  ← see resetClock quirk below
+await actual.sync();                    // initial file sync
+for (const account of accounts) {
+    await actual.runBankSync({ accountId: account.id });
+}
+await actual.sync();                    // final file sync
+// always in finally:
+await actual.shutdown();
+```
+
+**`actual.shutdown()` MUST be called in a `finally` block** — it commits data and releases the SQLite lock. If it is skipped the budget file is left in an inconsistent state.
+
+## Available API methods (used in actual-sync)
+
+```javascript
+actual.init({ serverURL, password, dataDir })
+actual.downloadBudget(syncId, { password? })   // password only for E2EE budgets
+actual.loadBudget(localBudgetId)               // see resetClock quirk
+actual.sync()
+actual.getAccounts()                           // returns Account[]
+actual.runBankSync({ accountId })
+actual.shutdown()
+```
+
+## Known quirks — read carefully
+
+### `resetClock: true` — `downloadBudget` does not open the budget in memory (26.x)
+
+When the Actual Budget server sets `resetClock: true` in the budget metadata (happens on first-time clients or after a "Reset sync" in the UI), `downloadBudget` in `@actual-app/api` 26.x writes `db.sqlite` and `metadata.json` to disk but does **not** open the budget in memory. The next API call (`getAccounts()`, `sync()`, etc.) throws `"No budget file is open"`.
+
+**Workaround** (implemented in `src/syncService.js` after the `downloadBudget` call):
+
+```javascript
+// Scan dataDir for the local budget ID and call loadBudget explicitly
+const entries = await fs.readdir(dataDir);
+for (const entry of entries) {
+    try {
+        const meta = JSON.parse(await fs.readFile(`${dataDir}/${entry}/metadata.json`, 'utf8'));
+        if (meta.groupId === syncId && meta.id) {
+            await actual.loadBudget(meta.id);
+            break;
+        }
+    } catch { /* not a budget dir */ }
+}
+```
+
+Symptoms: `metadata.json` has `"resetClock": true`, `cache.sqlite` is absent from the local budget folder, and `getAccounts()` fails 1ms after `downloadBudget` reports success.
+
+### `downloadBudget` leaves a partial cache on failure
+
+When `downloadBudget` fails midway (e.g. network drop), it writes a partial `db.sqlite` to `dataDir`. Subsequent sync attempts fail because the API tries to apply incremental changes on top of a broken local state — `cache.sqlite` is missing and the API throws an empty `PostError`. Fix: delete the budget subfolder in `dataDir` to force a full fresh download on the next attempt.
+
+### Empty `PostError` from `downloadBudget`
+
+The Actual API throws `PostError` internally but by the time it reaches actual-sync the error often has an empty message. `enhanceActualApiError()` in `src/syncService.js` detects this and synthesises a human-readable message (`"budget download failed"`). The original error code is accessible via `error.originalError`.
+
+### `actual.sync()` called twice per sync cycle
+
+`actual.sync()` is called **before** and **after** `runBankSync`. The first call pulls the latest budget state from the server before bank sync starts; the second commits the bank sync results back to the server. Skipping either call leaves the budget out of sync.
+
+### Multi-server isolation via `dataDir`
+
+Each server entry in config has its own `dataDir`. The Actual API stores the local SQLite budget files there. Never share a `dataDir` between two servers — the API uses a global singleton SQLite connection and will corrupt state.
+
+### Encrypted budgets — two passwords
+
+- `server.password` — authenticates to the Actual Budget HTTP server
+- `server.encryptionPassword` — decrypts the E2EE budget file (separate, optional)
+
+Pass `encryptionPassword` as the second argument to `downloadBudget`:
+```javascript
+await actual.downloadBudget(syncId, { password: encryptionPassword });
+```
+
+## Account schema fields
+
+```
+id, name, type, offbudget (boolean), closed (boolean), sort_order,
+account_sync_source, balance_current, balance_available, balance_limit
+```
+
+## Transaction schema fields
+
+```
+id, account (UUID), category (UUID), amount (integer cents),
+date (YYYY-MM-DD), payee (UUID), cleared, reconciled, notes,
+parent_id, is_child, transfer_id
+```
+
+## Amounts
+
+Always integer cents. Never decimal dollars.
+- `5000`  = $50.00
+- `-1234` = -$12.34 (expense)

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -1,0 +1,232 @@
+---
+name: qa
+description: "QA specialist for actual-sync. Validates test coverage, enforces Jest patterns, and knows the test helpers, mock conventions, and coverage thresholds. Invoke when writing tests, diagnosing coverage failures, or reviewing test structure."
+model: sonnet
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+---
+
+You are the **QA specialist** for actual-sync. You validate test coverage, enforce Jest discipline, and ensure new code ships with appropriate tests.
+
+## Test structure
+
+All tests live in `src/__tests__/`. Shared helpers are in `src/__tests__/helpers/testHelpers.js`.
+
+```
+src/__tests__/
+├── helpers/
+│   └── testHelpers.js          ← always import from here
+├── configLoader.test.js
+├── healthCheck.test.js
+├── logger.test.js
+├── messageFormatter.test.js
+├── notificationService.test.js
+├── perServerConfig.test.js
+├── prometheusService.test.js
+├── retryLogic.test.js
+├── startupValidation.test.js
+├── syncHistory.test.js
+├── syncService.test.js
+└── telegramBot.test.js
+```
+
+## Test helpers — always use these
+
+Import from `src/__tests__/helpers/testHelpers.js`:
+
+```javascript
+const {
+    createMockConfig,
+    createTempDir,
+    cleanupTempDir,
+    createMockActualAPI,
+    suppressConsole,
+    wait
+} = require('./helpers/testHelpers');
+```
+
+### `createMockConfig(overrides = {})`
+
+Returns a base config object. Pass overrides to customise:
+
+```javascript
+const config = createMockConfig({
+    servers: [{
+        name: 'My Server',
+        url: 'https://actual.example.com',
+        password: 'secret',
+        syncId: 'abc-123',
+        dataDir: '/tmp/test'
+    }],
+    sync: { maxRetries: 1, baseRetryDelayMs: 100 }
+});
+```
+
+### `createTempDir()` / `cleanupTempDir(dir)`
+
+Always use in `beforeEach` / `afterEach` — never hardcode temp paths:
+
+```javascript
+let tempDir;
+beforeEach(() => { tempDir = createTempDir(); });
+afterEach(() => { cleanupTempDir(tempDir); });
+```
+
+### `createMockActualAPI()`
+
+Returns a mock for `@actual-app/api` with jest.fn() for all methods:
+
+```javascript
+// Methods available: init, downloadBudget, loadBudget, runBankSync, sync, shutdown, getAccounts
+const mockApi = createMockActualAPI();
+mockApi.getAccounts.mockResolvedValue([{ id: 'acc1', name: 'Checking' }]);
+```
+
+### `suppressConsole()`
+
+Silences console output in tests that trigger logging:
+
+```javascript
+let suppress;
+beforeEach(() => { suppress = suppressConsole(); });
+afterEach(() => { suppress.restore(); });
+```
+
+## Mocking `@actual-app/api`
+
+Use `jest.mock` at the top of the test file, then import the module to access mocks:
+
+```javascript
+jest.mock('@actual-app/api', () => ({
+    init: jest.fn(),
+    downloadBudget: jest.fn(),
+    loadBudget: jest.fn(),
+    runBankSync: jest.fn(),
+    sync: jest.fn(),
+    shutdown: jest.fn(),
+    getAccounts: jest.fn()
+}));
+
+const actual = require('@actual-app/api');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    actual.init.mockResolvedValue(undefined);
+    actual.downloadBudget.mockResolvedValue(undefined);
+    actual.getAccounts.mockResolvedValue([{ id: 'acc1', name: 'Test' }]);
+    actual.sync.mockResolvedValue(undefined);
+    actual.shutdown.mockResolvedValue(undefined);
+});
+```
+
+## Standard test structure
+
+```javascript
+describe('ComponentName', () => {
+    let tempDir;
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+    });
+
+    afterEach(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    test('should do something specific', async () => {
+        // Arrange
+        const config = createMockConfig({ sync: { maxRetries: 0 } });
+
+        // Act
+        const result = await functionUnderTest(config);
+
+        // Assert
+        expect(result).toBe(expectedValue);
+    });
+});
+```
+
+## Coverage thresholds (enforced by Jest — failure breaks CI)
+
+| Metric | Threshold |
+|---|---|
+| Branches | 61% |
+| Functions | 70% |
+| Lines | 70% |
+| Statements | 70% |
+
+**Files excluded from coverage collection** (`package.json` jest config):
+- `src/syncService.js` — excluded intentionally
+- `index.js` — excluded intentionally
+- `src/**/*.test.js` — test files
+- `src/__tests__/**` — test helpers
+
+## Running tests
+
+```bash
+npm test                                          # all tests
+npm test -- configLoader.test.js                 # single file
+npm test -- --testNamePattern="should validate"  # by name pattern
+npm run test:watch -- syncService.test.js        # watch mode
+npm run test:coverage                            # with coverage report
+```
+
+## Key testing patterns
+
+### Error path testing
+
+```javascript
+test('should handle download failure', async () => {
+    actual.downloadBudget.mockRejectedValue(new Error('Network error'));
+    await expect(syncBank(server)).rejects.toThrow('Network error');
+    expect(actual.shutdown).toHaveBeenCalled(); // always verify shutdown is called
+});
+```
+
+### Verify `shutdown` is always called
+
+`actual.shutdown()` must be called even when an error occurs. Always assert it:
+
+```javascript
+expect(actual.shutdown).toHaveBeenCalledTimes(1);
+```
+
+### Schema validation tests (configLoader)
+
+```javascript
+test('should reject missing required field', () => {
+    const invalidConfig = createMockConfig({ servers: [] });
+    expect(() => new ConfigLoader().validate(invalidConfig))
+        .toThrow(/minItems/);
+});
+```
+
+### Notification service tests — mock external transport
+
+```javascript
+jest.mock('nodemailer');
+jest.mock('node-fetch');
+// Test that the right transport is called with the right payload
+```
+
+## What to test when adding new features
+
+1. **Happy path** — correct input produces correct output
+2. **Error paths** — failures are caught, logged, and `shutdown()` is always called
+3. **Config validation** — invalid config values are rejected with clear messages
+4. **Per-server overrides** — server-level config correctly overrides global config
+5. **Retry logic** — retryable errors trigger retries; non-retryable errors do not
+
+## Pre-commit check
+
+```bash
+npm test && echo "✅ All tests pass"
+```
+
+If adding new source files, also run:
+```bash
+npm run test:coverage  # verify coverage thresholds are still met
+```

--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -1,0 +1,127 @@
+---
+name: release-manager
+description: Release and git workflow expert for actual-sync. Invoke for version bumps, PR creation, GitHub issue triage, or enforcing git discipline. Knows the branch rules, commit conventions, Docker image deployment, and issue lifecycle.
+model: sonnet
+tools:
+  - Bash
+  - Read
+  - Glob
+---
+
+You are the **release manager** for actual-sync. You handle version bumps, PR lifecycle, GitHub issue management, and git workflow enforcement.
+
+## Git workflow — non-negotiable
+
+- **Never push directly to `main`**. All changes go through a PR.
+- Never run `git push` unless the user has explicitly asked for it in that message.
+- When code is ready, open a PR and present it for review — do not push.
+- Only push to `main` when the user says "push to main", "merge this", or "release".
+- `git commit` locally to prepare a PR is acceptable; pushing without instruction is not.
+
+## Pre-commit sequence
+
+```bash
+npm test          # all 300+ Jest tests must pass
+npm run test:coverage  # confirm coverage thresholds still met
+```
+
+Coverage thresholds (enforced by Jest — build fails if breached):
+- Branches: 61%
+- Functions: 70%
+- Lines: 70%
+- Statements: 70%
+
+## Version bump
+
+Version is in `package.json` → `"version"`. Bump manually following semver:
+- **patch** — bug fixes (`1.4.0` → `1.4.1`)
+- **minor** — new features (`1.4.0` → `1.5.0`)
+- **major** — breaking changes (`1.4.0` → `2.0.0`)
+
+After bumping, update the version in `src/syncService.js` if it is hardcoded there (check with grep).
+
+## Commit message conventions
+
+```
+feat: add loadBudget workaround for resetClock:true
+fix: clear local cache on failed downloadBudget
+chore(deps): bump @actual-app/api from 26.1.0 to 26.4.0
+chore: bump version to 1.4.1
+docs: update CONFIG.md with encryptionPassword field
+test: add coverage for resetClock download failure
+```
+
+Always add co-author trailer:
+```
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+## PR creation
+
+```bash
+gh pr create --title "fix: ..." --body "$(cat <<'EOF'
+## Summary
+- bullet points
+
+## Test plan
+- [ ] npm test passes
+- [ ] manual sync verified on NAS
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Docker image deployment (production — Synology DS220+)
+
+The production stack is at `/mnt/ds220p/docker/project/Finance-actual-budget/` on the locally mounted NAS. Image: `ghcr.io/agigante80/actual-sync:latest`.
+
+After merging a PR, pull and restart on the NAS:
+```bash
+# SSH into NAS or run from DSM:
+docker compose pull && docker compose up -d
+```
+
+CI builds and pushes the `latest` image automatically on push to `main` via GitHub Actions.
+
+## GitHub issue lifecycle
+
+### Closing a fixed issue
+
+Post a comment before closing:
+```
+Fixed in **vX.Y.Z** / PR #N.
+
+**Root cause:** <1–2 sentences>
+**Fix:** <what changed and why it works>
+```
+
+Then close:
+```bash
+gh issue close <number> --reason completed
+```
+
+### Check for duplicates before creating issues
+
+```bash
+gh issue list --state open --search "<keyword>" --json number,title
+```
+
+### Issue labels
+
+- `bug` — confirmed defect
+- `enhancement` — new feature or improvement
+- `infrastructure` — deps, CI, Docker
+
+## Dependency security rule
+
+Never use `npm overrides` to force transitive dependency versions. If a transitive dep has a vulnerability, upgrade the direct dependency that pulls it in.
+
+## Release checklist
+
+1. Run `npm test` — all tests pass
+2. Bump version in `package.json`
+3. Commit with `chore: bump version to X.Y.Z`
+4. Open PR → wait for review and approval
+5. Merge PR (this triggers CI to build and push `latest` image)
+6. Pull new image on NAS and restart stack

--- a/.claude/agents/ticket-gate.md
+++ b/.claude/agents/ticket-gate.md
@@ -1,0 +1,154 @@
+---
+name: ticket-gate
+description: "Ticket readiness gate for actual-sync. Orchestrates actual-api, qa, and release-manager agents to validate GitHub issues before implementation begins. Invoke via /review-ticket <issue-number>."
+model: sonnet
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Agent
+---
+
+# Ticket Readiness Gate for actual-sync
+
+You are the **ticket readiness gate** for actual-sync. You validate GitHub issues through 3 sequential specialist agents before implementation begins. Your job is to ensure every issue is specific enough, testable, and safe to implement.
+
+## Core Process
+
+### Step 1 — Fetch the issue
+
+```bash
+gh issue view <issue-number> --repo agigante80/Actual-sync --json number,title,body,labels,comments
+```
+
+### Step 2 — Load project context
+
+Read these files to ground your evaluation:
+- `CLAUDE.md` — conventions, rules, architecture overview
+- `src/syncService.js` — core sync logic and API usage patterns
+- `src/__tests__/helpers/testHelpers.js` — shared test utilities
+
+### Step 3 — Run 3 agents ONE AT A TIME (never in parallel)
+
+**CRITICAL: invoke one agent, wait for its result, then invoke the next. Never send two Agent tool calls in the same message. Each agent's output informs context for the next.**
+
+Invoke each agent using the Agent tool with `subagent_type` set to the agent name. Pass the full issue body and relevant context in each prompt. Each agent must return:
+
+```json
+{
+  "score": 1-10,
+  "status": "PASS" | "BLOCKED",
+  "notes": "concise summary",
+  "required_changes": ["exact change 1", "exact change 2"]
+}
+```
+
+**Score 10 = PASS. Any score below 10 = BLOCKED.**
+
+Execution order — strictly sequential:
+1. Invoke `actual-api` → wait for result → record score
+2. Invoke `qa` → wait for result → record score
+3. Invoke `release-manager` → wait for result → record score
+
+---
+
+#### Agent 1: `actual-api`
+
+Validates API correctness. Prompt must include:
+- Full issue body
+- Current `syncService.js` relevant sections (lines around the API call sequence)
+- Question: "Does this issue correctly use the @actual-app/api lifecycle? Are all method names, field names, and lifecycle rules correct? Does the issue acknowledge the resetClock quirk if relevant?"
+
+The `actual-api` agent evaluates:
+- Correct `init → downloadBudget → [loadBudget] → sync → runBankSync → sync → shutdown` lifecycle
+- `actual.shutdown()` called in `finally` block — always
+- Field names match documented schema (`account.id`, `account.name`, integer-cent amounts)
+- Known quirks acknowledged where relevant (resetClock, partial cache, empty PostError)
+- Multi-server isolation via separate `dataDir` per server
+
+Auto-scores 10 when the issue has no Actual Budget API interaction.
+
+---
+
+#### Agent 2: `qa`
+
+Validates test coverage plan. Prompt must include:
+- Full issue body
+- `src/__tests__/helpers/testHelpers.js` content
+- List of existing test files in `src/__tests__/`
+- Question: "Does this issue describe specific test cases with inputs and expected outputs? Does it cover error paths and call actual.shutdown() verification?"
+
+The `qa` agent evaluates:
+- Specific test cases described with concrete inputs/outputs
+- Error path coverage (what happens when API calls fail)
+- `actual.shutdown()` called in `finally` — always assert this in tests
+- Use of shared helpers (`createMockConfig`, `createMockActualAPI`, `createTempDir`)
+- Coverage thresholds still met (61% branches, 70% functions/lines/statements)
+- No test file excluded from coverage collection (`syncService.js` and `index.js` are excluded — new files are not)
+
+Auto-scores 10 when the issue is documentation-only or infrastructure-only with no code changes.
+
+---
+
+#### Agent 3: `release-manager`
+
+Validates PR scope and git workflow compliance. Prompt must include:
+- Full issue body
+- Current `package.json` version field
+- Question: "Is this issue scoped for a clean PR? Does it follow the git workflow rules? Is the version bump appropriate?"
+
+The `release-manager` agent evaluates:
+- Change goes through a PR — never directly to `main`
+- Commit message follows convention (`feat:`, `fix:`, `chore:`, `docs:`, `test:`)
+- Version bump is identified and appropriate (patch/minor/major)
+- Acceptance criteria are measurable (not "should work better")
+- PR scope is focused — not mixing bug fix with unrelated refactor
+- No `npm overrides` to silence vulnerabilities — upgrade the direct dependency
+
+---
+
+### Step 4 — Compile scorecard
+
+Format results as a markdown table:
+
+```
+## Ticket Readiness Gate — Issue #<number>
+
+| Agent | Score | Status | Key Findings |
+|-------|-------|--------|--------------|
+| actual-api | X/10 | PASS/BLOCKED | ... |
+| qa | X/10 | PASS/BLOCKED | ... |
+| release-manager | X/10 | PASS/BLOCKED | ... |
+
+### Overall: PASS ✅ / BLOCKED 🚫
+
+**Required changes before implementation:**
+1. ...
+2. ...
+```
+
+### Step 5 — Post scorecard as GitHub comment
+
+```bash
+gh issue comment <issue-number> --repo agigante80/Actual-sync --body "$(cat <<'EOF'
+<scorecard markdown here>
+EOF
+)"
+```
+
+### Step 6 — Report result
+
+- **All scores 10/10** → PASS. Implementation may begin.
+- **Any score < 10** → BLOCKED. List all required changes precisely. No vague feedback — every item must state exactly what to add or fix.
+
+## Re-runs
+
+Re-runs only re-score agents that were below 10. Carry forward previous passing scores unchanged.
+
+## Critical Rules
+
+- **Sequential execution only.** Never invoke two agents in the same message. One Agent tool call per message, wait for the result before proceeding.
+- **Minimum 10/10 from every agent.** No partial passes.
+- **Agents must be specific.** Vague feedback ("needs more detail") is rejected. Every required change must state exactly what to add or fix.
+- **Never suggest implementation** — your job is validation, not writing code.

--- a/.claude/commands/dep-auditor.md
+++ b/.claude/commands/dep-auditor.md
@@ -1,0 +1,87 @@
+# Dependency Audit for actual-sync
+
+Runs a four-check dependency health audit and creates GitHub issues for findings.
+Accepts optional `[--full]` flag. Default is cache-first (skip packages audited within 30 days).
+
+## Four sequential checks
+
+### Check 1: Known vulnerabilities (`npm audit`)
+
+```bash
+cd /home/alien/dev-github-personal/Actual-sync
+npm audit --json
+```
+
+Parse output and create GitHub issues for **moderate / high / critical** findings. Each issue must include:
+- CVE or advisory ID
+- Affected package and version range
+- Dependency path (which direct dep pulls it in)
+- Recommended upgrade command
+
+**Security rule**: never suggest `npm overrides` to silence a vulnerability — always upgrade the direct dependency.
+
+### Check 2: Registry health
+
+For each **direct** dependency in `package.json` (not cached within 30 days), fetch npm metadata:
+
+```bash
+npm show <package> --json
+# Fields: time (latest publish), deprecated, dist-tags.latest
+# Weekly downloads: https://api.npmjs.org/downloads/point/last-week/<package>
+```
+
+Severity thresholds:
+- **Critical**: deprecated or < 1,000 weekly downloads
+- **Warning**: > 12 months since last publish OR < 10,000 weekly downloads
+- **Info**: 6–12 months since last publish
+
+Create one issue per finding with alternatives research and migration effort estimate.
+
+### Check 3: Version drift
+
+```bash
+npm outdated --json
+```
+
+Flag packages **1+ major versions** behind latest. Create issues with:
+- Current vs latest version
+- Link to changelog / release notes (if findable)
+- Affected files (grep for `require('<package>')`)
+- Effort estimate (patch = trivial, minor = low, major = medium/high)
+
+Note 2+ minor version gaps as informational in the same issue.
+
+**Skip**: devDependencies that don't affect production behaviour (pure test tooling gaps are low priority).
+
+### Check 4: Open Dependabot PRs
+
+```bash
+gh pr list --repo agigante80/Actual-sync --state open --json number,title,createdAt,labels \
+  | jq '.[] | select(.labels[].name == "dependencies")'
+```
+
+Summarise all pending Dependabot PRs by age. Flag any older than 60 days for prioritisation.
+
+## Deduplication
+
+Before creating any issue, check for an existing open issue:
+```bash
+gh issue list --state open --search "<package-name>" --json number,title
+```
+
+Skip creation if a matching issue already exists; add a comment to the existing one instead.
+
+## Output format
+
+After all checks, display a summary table:
+
+```
+| Check | Findings | Issues created | Skipped (cached) |
+|-------|----------|----------------|------------------|
+| npm audit | 2 high | 2 | 0 |
+| Registry health | 1 warning | 1 | 8 |
+| Version drift | 3 outdated | 2 | 1 (dup) |
+| Dependabot PRs | 15 open | — | — |
+```
+
+Label all created issues with `infrastructure`.

--- a/.claude/commands/local-env.md
+++ b/.claude/commands/local-env.md
@@ -1,0 +1,75 @@
+# Local environment — build and test actual-sync
+
+Builds actual-sync from the local dev source and runs it against the local Actual Budget instance.
+
+## Environment layout
+
+```
+/home/alien/docker/librechat-MCP-actual/
+├── actual-sync/              ← builds from /home/alien/dev-github-personal/Actual-sync
+│   ├── docker-compose.yml
+│   ├── Dockerfile
+│   └── config/config.json   ← two servers: "Main's Budget" + "TEST BLANK"
+└── Finance-actual-budget/   ← local Actual Budget server (port 5006)
+```
+
+The `docker-compose.yml` uses a `build.context` pointing at the local dev repo, so every `docker compose up --build` picks up uncommitted source changes.
+
+## Start the local Actual Budget server (if not running)
+
+```bash
+cd /home/alien/docker/librechat-MCP-actual/Finance-actual-budget
+docker compose up -d
+```
+
+Actual Budget available at: `http://localhost:5006`
+
+## Build and start actual-sync from local source
+
+```bash
+cd /home/alien/docker/librechat-MCP-actual/actual-sync
+docker compose up --build -d
+```
+
+Dashboard: `http://localhost:3000/dashboard`
+Health:    `http://localhost:3000/health`
+
+## Force a sync run (bypass scheduler)
+
+```bash
+# All servers
+docker compose -f /home/alien/docker/librechat-MCP-actual/actual-sync/docker-compose.yml \
+  exec actual-sync node index.js --force-run
+
+# One specific server
+docker compose -f /home/alien/docker/librechat-MCP-actual/actual-sync/docker-compose.yml \
+  exec actual-sync node index.js --force-run --server "Main's Budget"
+```
+
+## View live logs
+
+```bash
+docker logs -f actual-sync
+```
+
+## Stop everything
+
+```bash
+cd /home/alien/docker/librechat-MCP-actual/actual-sync && docker compose down
+cd /home/alien/docker/librechat-MCP-actual/Finance-actual-budget && docker compose down
+```
+
+## Test servers in config
+
+| Name | Actual server | Schedule | Encrypted |
+|---|---|---|---|
+| Main's Budget | finance-actual-budget-main:5006 | none (manual only) | No |
+| TEST BLANK | finance-actual-budget-main:5006 | none (manual only) | No |
+
+## Typical dev workflow
+
+1. Make code changes in `/home/alien/dev-github-personal/Actual-sync/`
+2. Run `npm test` to verify locally
+3. `docker compose up --build -d` in the actual-sync folder to rebuild
+4. Trigger a sync via dashboard or `--force-run` and check logs
+5. Confirm behaviour before opening a PR

--- a/.claude/commands/review-ticket.md
+++ b/.claude/commands/review-ticket.md
@@ -1,0 +1,45 @@
+# Review GitHub ticket readiness
+
+Run the ticket readiness gate on a GitHub issue before implementation begins.
+
+## Usage
+
+```
+/review-ticket <issue-number>
+```
+
+**Argument**: GitHub issue number (required). Example: `/review-ticket 44`
+
+## What this does
+
+Invokes the `ticket-gate` agent, which validates the issue through 3 sequential specialist agents:
+
+1. **actual-api** — verifies correct `@actual-app/api` lifecycle, method names, field names, and known quirks
+2. **qa** — verifies test cases are specific and cover error paths, shutdown assertions, and coverage thresholds
+3. **release-manager** — verifies PR scope, commit convention, version bump, and measurable acceptance criteria
+
+Each agent scores the issue 1–10. All three must score 10/10 for the issue to PASS.
+
+## Output
+
+The gate posts a scorecard as a GitHub comment on the issue and reports:
+
+- **PASS** — implementation may begin
+- **BLOCKED** — exact list of required changes; re-run after addressing them
+
+## Steps
+
+Use the Agent tool with `subagent_type: ticket-gate`, passing the following prompt:
+
+```
+Run the ticket readiness gate on GitHub issue #<issue-number> in agigante80/Actual-sync.
+
+Follow all steps in the ticket-gate agent instructions:
+1. Fetch the issue with gh issue view
+2. Load CLAUDE.md, src/syncService.js (API call sequence), and src/__tests__/helpers/testHelpers.js
+3. Run actual-api agent — wait for result — then qa agent — wait for result — then release-manager agent.
+   IMPORTANT: one agent per message, strictly sequential, never in parallel.
+4. Compile the scorecard
+5. Post it as a GitHub comment
+6. Report PASS or BLOCKED with required changes
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,194 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Actual-sync** is a self-hosted Node.js service that automates bank transaction synchronization for [Actual Budget](https://actualbudget.org/) servers. It supports multiple budget instances, encrypted budgets, scheduling, multi-channel notifications, and a web dashboard with Prometheus metrics.
+
+## Commands
+
+```bash
+# Run all tests
+npm test
+
+# Run a single test file
+npm test -- configLoader.test.js
+
+# Run tests matching a name pattern
+npm test -- --testNamePattern="should validate configuration"
+
+# Watch mode for a specific file
+npm run test:watch -- syncService.test.js
+
+# Generate coverage report
+npm run test:coverage
+
+# Start the scheduled sync service
+npm start
+
+# Force immediate sync (all servers)
+npm run sync
+
+# Sync a specific server
+npm run sync -- --server "ServerName"
+
+# Validate config against schema
+npm run validate-config
+
+# List discovered bank accounts
+npm run list-accounts
+
+# View sync history
+npm run history
+```
+
+No build step — this is plain JavaScript (no TypeScript, no bundler).
+
+### Docker Development
+
+```bash
+# Build image
+docker build -t actual-sync:dev .
+
+# Run locally with volume mounts (note: image runs as non-root UID 1001)
+docker run --rm \
+  -v ./config:/app/config:ro \
+  -v ./data:/app/data \
+  -v ./logs:/app/logs \
+  actual-sync:dev
+```
+
+## Architecture
+
+### Core Data Flow
+
+```
+Scheduler (node-schedule) or manual trigger
+  → syncAllBanks() → syncBank(server) [per server]
+    → Correlation ID assigned
+    → actual.init() → actual.downloadBudget() → actual.getAccounts()
+    → actual.sync() [initial state sync]
+    → bankSync per account with runWithRetries() [exponential backoff]
+    → actual.sync() [final state sync]
+    → Results tracked in SQLite + Prometheus
+    → Thresholds evaluated → Notifications dispatched
+    → actual.shutdown()
+```
+
+### Service Initialization (Dependency Injection)
+
+`index.js` validates startup, then `src/syncService.js` wires all services together:
+
+- `lib/configLoader.js` — AJV schema validation against `config/config.schema.json`
+- `lib/logger.js` — Custom structured logger (no Winston/Pino); supports file rotation and correlation IDs
+- `services/syncHistory.js` — SQLite-backed sync history via `better-sqlite3`
+- `services/healthCheck.js` — Express HTTP server (`/health`, `/ready`, `/metrics`, `/prometheus`, `/dashboard`, `/ws`)
+- `services/prometheusService.js` — Prometheus metrics via `prom-client`
+- `services/notificationService.js` — Routes alerts to Email/Telegram/Slack/Discord
+- `services/telegramBot.js` — Interactive Telegram bot (8 commands)
+
+Each service receives options and a logging config object:
+
+```javascript
+new ServiceClass(options, {
+    level: config.logging.level,
+    format: config.logging.format,
+    logDir: config.logging.logDir
+});
+```
+
+### Key Patterns
+
+**Retry logic**: `runWithRetries()` in `syncService.js` wraps bank sync calls with exponential backoff + jitter. Retryable errors: `ECONNREFUSED`, `ENOTFOUND`, `ETIMEDOUT`, HTTP 429.
+
+**Correlation IDs**: Set at the start of each sync operation, always cleared in `finally` blocks alongside `actual.shutdown()`:
+
+```javascript
+const correlationId = logger.generateCorrelationId();
+logger.setCorrelationId(correlationId);
+try {
+    // ... sync operations ...
+} finally {
+    logger.clearCorrelationId();
+    await actual.shutdown();
+}
+```
+
+**Multi-server isolation**: Each server gets its own data directory to avoid Actual Budget API state collisions.
+
+**Per-server config resolution**: Use `getSyncConfig(server)` to merge server-level overrides with global config — never access `server.sync.*` fields directly.
+
+**Health status states**: `HealthCheckService` tracks `HEALTHY`, `DEGRADED`, `UNHEALTHY`, and `PENDING`. The `/ready` endpoint returns 503 when `UNHEALTHY`.
+
+### Logging Convention
+
+Always use the custom logger from `src/lib/logger.js` — never add Winston, Pino, or other logging libraries.
+
+```javascript
+// CORRECT — concise message + structured metadata
+logger.info('Starting sync', { server: name, url, dataDir, maxRetries });
+logger.error('Attempt failed', { attempt: i + 1, error: err.message, errorCode: err.code });
+
+// AVOID — data embedded in message string
+logger.info(`Starting sync for ${name} at ${url} with ${maxRetries} retries`);
+```
+
+Log levels: `ERROR` (failures), `WARN` (retries/threshold warnings), `INFO` (normal operations), `DEBUG` (verbose).
+
+### Configuration
+
+Config is JSON, validated at startup against `config/config.schema.json`. See `config/config.example.json` for a reference template. Per-server settings can override global `sync` and `logging` sections. Encryption passwords for E2EE budgets are set per server (`encryptionPassword` field).
+
+### Actual Budget API
+
+Key methods from `@actual-app/api` used in sync operations:
+
+- `actual.init({ serverURL, password, dataDir })` — connect and prepare
+- `actual.downloadBudget(syncId, { password? })` — download budget (password only for E2EE)
+- `actual.sync()` — sync local budget file with server (called before and after bank sync)
+- `actual.runBankSync({ accountId })` — trigger bank sync for one account
+- `actual.getAccounts()` — retrieve all accounts in budget
+- `actual.shutdown()` — **always call in `finally` block**
+
+## Testing
+
+Tests live in `src/__tests__/`. Use the shared helpers in `src/__tests__/helpers/testHelpers.js`:
+
+- `createMockConfig(overrides)` — base test config with optional overrides
+- `createTempDir()` / `cleanupTempDir(dir)` — temp directory lifecycle
+- `createMockActualAPI()` — mock for `@actual-app/api`
+
+Coverage thresholds enforced by Jest: 61% branches, 70% functions/lines/statements.
+
+Note: `src/syncService.js` and `index.js` are excluded from coverage collection (see `package.json` jest config).
+
+## Adding New Features
+
+1. Add configuration to `config/config.schema.json` with description and examples
+2. Add business logic validation in `src/lib/configLoader.js` → `validateLogic()`
+3. Initialize service in `src/syncService.js` with the logger config pattern above
+4. Add tests in `src/__tests__/<feature>.test.js` using the test helpers
+5. Update relevant `docs/` files to match changed behavior
+
+## Git Workflow
+
+**Never push to `main` directly.** All code changes must go through a PR and wait for explicit user approval before merging or pushing. Do not run `git push` unless the user has explicitly asked for it in that message. Open a PR and present it for review instead.
+
+## Anti-Patterns to Avoid
+
+- Adding external logging libraries — use the custom logger
+- Modifying retry logic without updating tests
+- Changing config schema without updating `config/config.example.json`
+- Skipping correlation IDs in sync operations
+- Forgetting `actual.shutdown()` in finally blocks
+- Accessing `server.sync.*` directly instead of using `getSyncConfig(server)`
+- Skipping documentation updates when changing observable behavior
+
+## Documentation
+
+Comprehensive guides live in `docs/`. Key references:
+- `docs/ARCHITECTURE.md` — deeper architectural detail
+- `docs/TESTING.md` — testing patterns and conventions
+- `docs/CONFIG.md` — full configuration reference
+- `.github/copilot-instructions.md` — additional AI-specific coding patterns

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "actual-sync",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actual-sync",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "^26.1.0",
+        "@actual-app/api": "^26.4.0",
         "ajv": "^8.17.1",
         "better-sqlite3": "^12.5.0",
         "cronstrue": "^3.9.0",
@@ -34,13 +34,14 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.1.0.tgz",
-      "integrity": "sha512-AXAQ93++XeCZdVU/wkxellxeehNfL0Zx7kSEDsW84nSVInuqmo+mlk5oi+fRpuXAcITLpkk9YcznYhKI7HfExg==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.4.0.tgz",
+      "integrity": "sha512-U0uRKiXy62nQ60QyVikdKP2QhGcwGOY1JL6AioN5BtkN+5liZ1Onn/TlAhpUZi18UJ5NpHRuW7zyz4/MfcoCEA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/crdt": "^2.1.0",
-        "better-sqlite3": "^12.4.1",
+        "@actual-app/core": "26.4.0",
+        "@actual-app/crdt": "2.1.0",
+        "better-sqlite3": "^12.6.2",
         "compare-versions": "^6.1.1",
         "node-fetch": "^3.3.2",
         "uuid": "^13.0.0"
@@ -50,6 +51,69 @@
       }
     },
     "node_modules/@actual-app/api/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@actual-app/core": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.4.0.tgz",
+      "integrity": "sha512-vhzQNZQs5Ejc63jD6hXvlPWjvDsBmI9ODR3Y7CfesY4XLFbu98DZJRrBpLAMPus+TkupcsLzDtAjWpX2htTLBw==",
+      "license": "ISC",
+      "dependencies": {
+        "@jlongster/sql.js": "^1.6.7",
+        "@reduxjs/toolkit": "^2.11.2",
+        "@rschedule/core": "^1.5.0",
+        "@rschedule/json-tools": "^1.5.0",
+        "@rschedule/standard-date-adapter": "^1.5.0",
+        "absurd-sql": "0.0.54",
+        "adm-zip": "^0.5.16",
+        "better-sqlite3": "^12.6.2",
+        "csv-parse": "^6.1.0",
+        "csv-stringify": "^6.6.0",
+        "date-fns": "^4.1.0",
+        "handlebars": "^4.7.9",
+        "lru-cache": "^11.2.6",
+        "md5": "^2.3.0",
+        "memoize-one": "^6.0.0",
+        "mitt": "^3.0.1",
+        "promise-retry": "^2.0.1",
+        "slash": "5.1.0",
+        "typescript-strict-plugin": "^2.4.4",
+        "ua-parser-js": "^2.0.9",
+        "uuid": "^13.0.0"
+      }
+    },
+    "node_modules/@actual-app/core/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@actual-app/core/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@actual-app/core/node_modules/uuid": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
       "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
@@ -116,7 +180,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1023,6 +1086,12 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jlongster/sql.js": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@jlongster/sql.js/-/sql.js-1.6.7.tgz",
+      "integrity": "sha512-4hf0kZr5WPoirdR5hUSfQ9O0JpH/qlW1CaR2wZ6zGrDz1xjSdTPuR8AW/oXzIHnJvZSEvlcIE+dfXJZwh/Lxfw==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1168,6 +1237,56 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rschedule/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rschedule/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-uN6Kjx4dnpheesXx+wm0B3E+xJPCw3TdNFmNAIXj9oPVD5t4smbpu/IBPZIzfv8bf7I88s/ahDKkltU6W3H6dw==",
+      "license": "Unlicense"
+    },
+    "node_modules/@rschedule/json-tools": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rschedule/json-tools/-/json-tools-1.5.0.tgz",
+      "integrity": "sha512-vwqBc1qkkjE7JzU5wrgCNMBVBUJgWcA9t8zrFr6Dmtd/npEO2XRrKaH5zamFgwsl1O3xqk1Law6EbeH5TJ1RHQ==",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@rschedule/core": "^1.5.0"
+      }
+    },
+    "node_modules/@rschedule/standard-date-adapter": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rschedule/standard-date-adapter/-/standard-date-adapter-1.5.0.tgz",
+      "integrity": "sha512-gQUlCOmYVaGvq6IZT29VVl4uZhaauwgG9aWxXLvC7x3lSF1f+z52iLAj853Mc4a1UgXQtEwt7Wujb9twl740Ew==",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@rschedule/core": "^1.5.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
@@ -1194,6 +1313,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
@@ -1617,6 +1748,14 @@
         "win32"
       ]
     },
+    "node_modules/absurd-sql": {
+      "version": "0.0.54",
+      "resolved": "https://registry.npmjs.org/absurd-sql/-/absurd-sql-0.0.54.tgz",
+      "integrity": "sha512-p+SWTtpRs2t3sXMLxkTyLRZkEzxTv/zG/Bl93wibegLZTGAHGk68SJMWslRWHBGh63ka/ePGTXGHh1117++45Q==",
+      "dependencies": {
+        "safari-14-idb-fix": "^1.0.4"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1628,6 +1767,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -1689,7 +1837,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1856,7 +2003,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -1997,9 +2143,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.5.0.tgz",
-      "integrity": "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2064,7 +2210,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2103,7 +2248,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2252,7 +2396,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2273,6 +2416,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chownr": {
@@ -2317,6 +2469,30 @@
       "integrity": "sha512-+CmxIZ/L2vNcEfvNtLdU0ZQ6mbq3FZnwAP2PPTiKP+1QOoKwlKlPgb8UKV0Dds7QVaMnHm+FwSft2VB0s/SLjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2396,6 +2572,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2418,7 +2603,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2431,7 +2615,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/compare-versions": {
@@ -2565,7 +2748,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2576,12 +2758,43 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
+      "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -2650,6 +2863,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -2673,6 +2898,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2698,8 +2943,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
       "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -2795,6 +3039,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -2839,7 +3089,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3009,7 +3258,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3332,7 +3580,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -3474,11 +3721,31 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3609,6 +3876,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3715,11 +3992,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3733,6 +4015,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-number": {
@@ -3751,14 +4042,45 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3768,7 +4090,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4554,6 +4875,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/long-timeout": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
@@ -4614,6 +4951,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -4622,6 +4970,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -4639,7 +4993,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -4685,7 +5038,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4707,7 +5059,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4742,7 +5093,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mkdirp-classic": {
@@ -4820,6 +5170,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -4930,7 +5286,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -4976,7 +5331,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -4986,6 +5340,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -5149,7 +5547,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5314,6 +5711,19 @@
       },
       "engines": {
         "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/proxy-addr": {
@@ -5509,11 +5919,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5527,6 +5951,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -5549,6 +5979,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rotating-file-stream": {
@@ -5578,6 +6036,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safari-14-idb-fix": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
+      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA==",
+      "license": "Apache-2.0"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5664,7 +6128,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5677,7 +6140,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5874,7 +6336,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6096,7 +6557,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6115,7 +6575,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -6340,6 +6799,249 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/typescript-strict-plugin": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/typescript-strict-plugin/-/typescript-strict-plugin-2.4.4.tgz",
+      "integrity": "sha512-OXcWHQk+pW9gqEL/Mb1eTgj/Yiqk1oHBERr9v4VInPOYN++p+cXejmQK/h/VlUPGD++FXQ8pgiqVMyEtxU4T6A==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "execa": "^4.0.0",
+        "minimatch": "^9.0.3",
+        "ora": "^5.4.1",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "tsc-strict": "dist/cli/tsc-strict/index.js",
+        "update-strict-comments": "dist/cli/update-strict-comments/index.js"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/typescript-strict-plugin/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/typescript-strict-plugin/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
+      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -6475,6 +7177,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -6494,7 +7205,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6505,6 +7215,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -6646,7 +7362,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "url": ""
   },
   "dependencies": {
-    "@actual-app/api": "^26.1.0",
+    "@actual-app/api": "^26.4.0",
     "ajv": "^8.17.1",
     "better-sqlite3": "^12.5.0",
     "cronstrue": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-sync",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Automated bank synchronization service for Actual Budget",
   "main": "index.js",
   "scripts": {

--- a/src/__tests__/syncService.test.js
+++ b/src/__tests__/syncService.test.js
@@ -2,8 +2,12 @@
  * Integration tests for syncService
  */
 
+const fs = require('fs').promises;
+const path = require('path');
 const {
     createMockActualAPI,
+    createTempDir,
+    cleanupTempDir,
     suppressConsole
 } = require('./helpers/testHelpers');
 
@@ -12,6 +16,7 @@ jest.mock('@actual-app/api', () => {
     return {
         init: jest.fn(),
         downloadBudget: jest.fn(),
+        loadBudget: jest.fn(),
         runBankSync: jest.fn(),
         sync: jest.fn(),
         shutdown: jest.fn(),
@@ -419,13 +424,196 @@ describe('syncService Integration Tests', () => {
             });
 
             // Empty string is falsy, so should not pass password
-            const downloadOptions = server.encryptionPassword 
-                ? { password: server.encryptionPassword } 
+            const downloadOptions = server.encryptionPassword
+                ? { password: server.encryptionPassword }
                 : undefined;
-            
+
             await actual.downloadBudget(server.syncId, downloadOptions);
 
             expect(actual.downloadBudget).toHaveBeenCalledWith('sync-789', undefined);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Fix 1: download failure clears dataDir
+    // Fix 4: loadBudget workaround for resetClock:true
+    // Fix 2: enhanceActualApiError preserves error.code / error.errorCode
+    // -------------------------------------------------------------------------
+    describe('Fix 1 — download failure clears dataDir', () => {
+        let tempDir;
+        let consoleSuppress;
+
+        beforeEach(async () => {
+            consoleSuppress = suppressConsole();
+            jest.clearAllMocks();
+            tempDir = createTempDir();
+            // Write a stale db.sqlite to simulate a corrupted partial download
+            await fs.writeFile(path.join(tempDir, 'db.sqlite'), 'corrupted');
+        });
+
+        afterEach(() => {
+            consoleSuppress.restore();
+            cleanupTempDir(tempDir);
+        });
+
+        test('dataDir is emptied after downloadBudget failure, error re-thrown, shutdown called', async () => {
+            actual.init.mockResolvedValue(undefined);
+            actual.downloadBudget.mockRejectedValue(new Error('Network error'));
+            actual.shutdown.mockResolvedValue(undefined);
+
+            // Test-local syncBank that mirrors the Fix 1 logic in syncService.js
+            async function syncBankWithCacheClearing(server) {
+                const { url, password, syncId, dataDir } = server;
+                try {
+                    await actual.init({ serverURL: url, password, dataDir });
+                    let downloadError;
+                    try {
+                        await actual.downloadBudget(syncId);
+                    } catch (err) {
+                        downloadError = err;
+                    }
+                    if (downloadError) {
+                        // Fix 1: clear corrupted cache before re-throwing
+                        await fs.rm(dataDir, { recursive: true, force: true });
+                        await fs.mkdir(dataDir, { recursive: true });
+                        throw downloadError;
+                    }
+                } finally {
+                    await actual.shutdown();
+                }
+            }
+
+            await expect(
+                syncBankWithCacheClearing({ url: 'http://x', password: 'p', syncId: 'sid', dataDir: tempDir })
+            ).rejects.toThrow('Network error');
+
+            // dataDir should exist but be empty (stale db.sqlite was removed)
+            const entries = await fs.readdir(tempDir);
+            expect(entries).toHaveLength(0);
+            expect(actual.shutdown).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Fix 4 — loadBudget workaround for resetClock:true', () => {
+        let tempDir;
+        let consoleSuppress;
+
+        beforeEach(async () => {
+            consoleSuppress = suppressConsole();
+            jest.clearAllMocks();
+            tempDir = createTempDir();
+            actual.init.mockResolvedValue(undefined);
+            actual.downloadBudget.mockResolvedValue(undefined);
+            actual.loadBudget.mockResolvedValue(undefined);
+            actual.sync.mockResolvedValue(undefined);
+            actual.getAccounts.mockResolvedValue([]);
+            actual.shutdown.mockResolvedValue(undefined);
+        });
+
+        afterEach(() => {
+            consoleSuppress.restore();
+            cleanupTempDir(tempDir);
+        });
+
+        // Helper: simulates the loadBudget workaround logic from syncService.js
+        async function runLoadBudgetWorkaround(dataDir, syncId) {
+            try {
+                const entries = await fs.readdir(dataDir);
+                for (const entry of entries) {
+                    try {
+                        const meta = JSON.parse(
+                            await fs.readFile(path.join(dataDir, entry, 'metadata.json'), 'utf8')
+                        );
+                        if (meta.groupId === syncId && meta.id) {
+                            await actual.loadBudget(meta.id);
+                            break;
+                        }
+                    } catch { /* not a budget directory, skip */ }
+                }
+            } catch { /* skip */ }
+        }
+
+        test('loadBudget called with local budget ID when metadata.json matches syncId', async () => {
+            const syncId = 'test-sync-id';
+            const localBudgetId = 'My-Budget-abc123';
+
+            // Create the budget subfolder with a matching metadata.json
+            const budgetDir = path.join(tempDir, localBudgetId);
+            await fs.mkdir(budgetDir);
+            await fs.writeFile(
+                path.join(budgetDir, 'metadata.json'),
+                JSON.stringify({ groupId: syncId, id: localBudgetId })
+            );
+
+            await runLoadBudgetWorkaround(tempDir, syncId);
+
+            expect(actual.loadBudget).toHaveBeenCalledTimes(1);
+            expect(actual.loadBudget).toHaveBeenCalledWith(localBudgetId);
+        });
+
+        test('loadBudget NOT called when no metadata.json matches syncId', async () => {
+            const syncId = 'test-sync-id';
+
+            // Create a budget folder whose groupId does NOT match
+            const budgetDir = path.join(tempDir, 'Other-Budget-xyz');
+            await fs.mkdir(budgetDir);
+            await fs.writeFile(
+                path.join(budgetDir, 'metadata.json'),
+                JSON.stringify({ groupId: 'different-sync-id', id: 'Other-Budget-xyz' })
+            );
+
+            await runLoadBudgetWorkaround(tempDir, syncId);
+
+            expect(actual.loadBudget).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Fix 2 — enhanceActualApiError preserves error.code and error.errorCode', () => {
+        let consoleSuppress;
+
+        beforeEach(() => {
+            consoleSuppress = suppressConsole();
+        });
+
+        afterEach(() => {
+            consoleSuppress.restore();
+        });
+
+        test('enhanced error carries code and errorCode from original error', () => {
+            const { enhanceActualApiError } = require('../lib/actualApiError');
+
+            const originalError = new Error('connection refused');
+            originalError.code = 'ECONNREFUSED';
+            originalError.errorCode = 'NET_ERR';
+
+            const logger = { warn: jest.fn(), debug: jest.fn() };
+            const result = enhanceActualApiError(
+                originalError,
+                { phase: 'download', serverUrl: 'http://x', syncId: 'abc', isEncrypted: false },
+                logger
+            );
+
+            expect(result.code).toBe('ECONNREFUSED');
+            expect(result.errorCode).toBe('NET_ERR');
+            expect(result.originalError).toBe(originalError);
+        });
+
+        test('enhanced error code fields are undefined when original error has none', () => {
+            const { enhanceActualApiError } = require('../lib/actualApiError');
+
+            const originalError = new Error('unknown failure');
+            // no .code or .errorCode on this error
+
+            const logger = { warn: jest.fn(), debug: jest.fn() };
+            const result = enhanceActualApiError(
+                originalError,
+                { phase: 'download', serverUrl: 'http://x', syncId: 'abc', isEncrypted: false },
+                logger
+            );
+
+            expect(result.code).toBeUndefined();
+            expect(result.errorCode).toBeUndefined();
+            expect(result.originalError).toBe(originalError);
         });
     });
 });

--- a/src/lib/actualApiError.js
+++ b/src/lib/actualApiError.js
@@ -1,0 +1,108 @@
+/**
+ * Enhances errors thrown by @actual-app/api with human-readable context
+ * and troubleshooting guidance.
+ *
+ * @param {Error} error - The original error from the API
+ * @param {{ phase: string, serverUrl: string, syncId: string, isEncrypted: boolean }} context
+ * @param {{ warn: Function, debug: Function }} logger
+ * @returns {Error} Enhanced error with .originalError, .phase, .code, .errorCode
+ */
+function enhanceActualApiError(error, context, logger) {
+    const { phase, serverUrl, syncId, isEncrypted } = context;
+
+    // The Actual API throws PostError but by the time we catch it, it's often a plain Error with no message
+    let originalError = error?.message || error?.toString() || '';
+
+    // Check for empty or generic error - common with PostError that loses its details
+    if (!originalError || originalError === 'Error' || originalError.trim() === '') {
+        if (phase === 'download' && isEncrypted) {
+            originalError = 'network-failure during encryption key validation';
+            logger.warn('Empty error caught for encrypted budget download - likely encryption key issue');
+        } else if (phase === 'download') {
+            originalError = 'budget download failed';
+            logger.warn('Empty error caught for budget download');
+        } else {
+            originalError = 'sync operation failed';
+            logger.warn('Empty error caught during sync phase');
+        }
+    }
+
+    // Check if this is a PostError with a reason field
+    if (error?.type === 'PostError' && error?.reason) {
+        originalError = error.reason;
+        logger.debug('PostError detected with reason', { reason: error.reason });
+    }
+
+    // Check the string representation for PostError pattern
+    const errorString = error?.toString() || '';
+    if (errorString.includes('PostError: PostError: ')) {
+        const match = errorString.match(/PostError: PostError: (.+)/);
+        if (match && match[1]) {
+            originalError = match[1].trim();
+        }
+    }
+
+    // Check stack trace for PostError pattern
+    if (error?.stack && error.stack.includes('PostError: PostError: ')) {
+        const stackMatch = error.stack.match(/PostError: PostError: (.+)/);
+        if (stackMatch && stackMatch[1]) {
+            originalError = stackMatch[1].split('\n')[0].trim();
+        }
+    }
+
+    // Build contextual troubleshooting guidance
+    const errorDetails = [];
+
+    if (phase === 'download') {
+        if (originalError.includes('Could not get remote files')) {
+            errorDetails.push('Failed to retrieve budget files from server.');
+            errorDetails.push(`Verify that Sync ID "${syncId}" exists on server "${serverUrl}".`);
+            errorDetails.push('Check that file sync is enabled in your Actual Budget server settings.');
+            if (!isEncrypted) {
+                errorDetails.push('If this budget uses encryption, provide the encryptionPassword in config.');
+            }
+        } else if (originalError.includes('network-failure')) {
+            if (isEncrypted) {
+                errorDetails.push('Network connection to Actual Budget server failed during encryption key validation.');
+                errorDetails.push(`Check that server is accessible at: ${serverUrl}`);
+                errorDetails.push('Verify the encryptionPassword is correct for this encrypted budget.');
+                errorDetails.push('Ensure the Actual Budget server supports encrypted budgets.');
+            } else {
+                errorDetails.push('Network connection to Actual Budget server failed.');
+                errorDetails.push(`Check that server is accessible at: ${serverUrl}`);
+                errorDetails.push('Verify the server password is correct.');
+            }
+        } else if (originalError.includes('decrypt-failure') || originalError.includes('Invalid password')) {
+            errorDetails.push('Failed to decrypt budget file.');
+            errorDetails.push('Verify the encryptionPassword is correct for this budget.');
+        } else if (originalError.includes('unauthorized')) {
+            errorDetails.push('Authentication failed.');
+            errorDetails.push('Verify the server password is correct.');
+        }
+    } else if (phase === 'sync') {
+        if (originalError.includes('network-failure')) {
+            errorDetails.push('Network connection lost during file synchronization.');
+            errorDetails.push(`Check server connectivity at: ${serverUrl}`);
+            errorDetails.push('This may be a transient network issue - sync will retry on next schedule.');
+        } else if (originalError.includes('sync-error')) {
+            errorDetails.push('File synchronization conflict detected.');
+            errorDetails.push('This may occur if budget was modified on server during sync.');
+            errorDetails.push('Retry will automatically resolve most conflicts.');
+        }
+    }
+
+    // Create enhanced error message
+    const enhancedMessage = errorDetails.length > 0
+        ? `${originalError}\n\nTroubleshooting:\n- ${errorDetails.join('\n- ')}`
+        : originalError;
+
+    const enhancedError = new Error(enhancedMessage);
+    enhancedError.originalError = error;
+    enhancedError.phase = phase;
+    enhancedError.code = error?.code;
+    enhancedError.errorCode = error?.errorCode;
+
+    return enhancedError;
+}
+
+module.exports = { enhanceActualApiError };

--- a/src/syncService.js
+++ b/src/syncService.js
@@ -10,6 +10,7 @@ const { SyncHistoryService } = require('./services/syncHistory');
 const { NotificationService } = require('./services/notificationService');
 const { TelegramBotService } = require('./services/telegramBot');
 const PrometheusService = require('./services/prometheusService');
+const { enhanceActualApiError } = require('./lib/actualApiError');
 
 // Get version
 const VERSION = process.env.VERSION || (() => {
@@ -19,113 +20,6 @@ const VERSION = process.env.VERSION || (() => {
         return 'unknown';
     }
 })();
-
-/**
- * Enhance Actual API errors with contextual troubleshooting information
- * @param {Error} error - Original error from @actual-app/api
- * @param {Object} context - Context information about the sync operation
- * @param {string} context.phase - Sync phase: 'download' or 'sync'
- * @param {string} context.serverUrl - Actual Budget server URL
- * @param {string} context.syncId - Budget sync ID
- * @param {boolean} context.isEncrypted - Whether budget uses encryption
- * @param {Object} logger - Logger instance for debug messages
- * @returns {Error} Enhanced error with troubleshooting guidance
- */
-function enhanceActualApiError(error, context, logger) {
-    const { phase, serverUrl, syncId, isEncrypted } = context;
-    
-    // The Actual API throws PostError but by the time we catch it, it's often a plain Error with no message
-    let originalError = error?.message || error?.toString() || '';
-    
-    // Check for empty or generic error - common with PostError that loses its details
-    if (!originalError || originalError === 'Error' || originalError.trim() === '') {
-        if (phase === 'download' && isEncrypted) {
-            originalError = 'network-failure during encryption key validation';
-            logger.warn('Empty error caught for encrypted budget download - likely encryption key issue');
-        } else if (phase === 'download') {
-            originalError = 'budget download failed';
-            logger.warn('Empty error caught for budget download');
-        } else {
-            originalError = 'sync operation failed';
-            logger.warn('Empty error caught during sync phase');
-        }
-    }
-    
-    // Check if this is a PostError with a reason field
-    if (error?.type === 'PostError' && error?.reason) {
-        originalError = error.reason;
-        logger.debug('PostError detected with reason', { reason: error.reason });
-    }
-    
-    // Check the string representation for PostError pattern
-    const errorString = error?.toString() || '';
-    if (errorString.includes('PostError: PostError: ')) {
-        const match = errorString.match(/PostError: PostError: (.+)/);
-        if (match && match[1]) {
-            originalError = match[1].trim();
-        }
-    }
-    
-    // Check stack trace for PostError pattern
-    if (error?.stack && error.stack.includes('PostError: PostError: ')) {
-        const stackMatch = error.stack.match(/PostError: PostError: (.+)/);
-        if (stackMatch && stackMatch[1]) {
-            originalError = stackMatch[1].split('\n')[0].trim();
-        }
-    }
-    
-    // Build contextual troubleshooting guidance
-    const errorDetails = [];
-    
-    if (phase === 'download') {
-        if (originalError.includes('Could not get remote files')) {
-            errorDetails.push('Failed to retrieve budget files from server.');
-            errorDetails.push(`Verify that Sync ID "${syncId}" exists on server "${serverUrl}".`);
-            errorDetails.push('Check that file sync is enabled in your Actual Budget server settings.');
-            if (!isEncrypted) {
-                errorDetails.push('If this budget uses encryption, provide the encryptionPassword in config.');
-            }
-        } else if (originalError.includes('network-failure')) {
-            if (isEncrypted) {
-                errorDetails.push('Network connection to Actual Budget server failed during encryption key validation.');
-                errorDetails.push(`Check that server is accessible at: ${serverUrl}`);
-                errorDetails.push('Verify the encryptionPassword is correct for this encrypted budget.');
-                errorDetails.push('Ensure the Actual Budget server supports encrypted budgets.');
-            } else {
-                errorDetails.push('Network connection to Actual Budget server failed.');
-                errorDetails.push(`Check that server is accessible at: ${serverUrl}`);
-                errorDetails.push('Verify the server password is correct.');
-            }
-        } else if (originalError.includes('decrypt-failure') || originalError.includes('Invalid password')) {
-            errorDetails.push('Failed to decrypt budget file.');
-            errorDetails.push('Verify the encryptionPassword is correct for this budget.');
-        } else if (originalError.includes('unauthorized')) {
-            errorDetails.push('Authentication failed.');
-            errorDetails.push('Verify the server password is correct.');
-        }
-    } else if (phase === 'sync') {
-        if (originalError.includes('network-failure')) {
-            errorDetails.push('Network connection lost during file synchronization.');
-            errorDetails.push(`Check server connectivity at: ${serverUrl}`);
-            errorDetails.push('This may be a transient network issue - sync will retry on next schedule.');
-        } else if (originalError.includes('sync-error')) {
-            errorDetails.push('File synchronization conflict detected.');
-            errorDetails.push('This may occur if budget was modified on server during sync.');
-            errorDetails.push('Retry will automatically resolve most conflicts.');
-        }
-    }
-    
-    // Create enhanced error message
-    const enhancedMessage = errorDetails.length > 0 
-        ? `${originalError}\n\nTroubleshooting:\n- ${errorDetails.join('\n- ')}`
-        : originalError;
-    
-    const enhancedError = new Error(enhancedMessage);
-    enhancedError.originalError = error;
-    enhancedError.phase = phase;
-    
-    return enhancedError;
-}
 
 /**
  * Format next sync time in human-readable format
@@ -517,8 +411,19 @@ async function syncBank(server, options = {}) {
             });
         }
         
-        // If download failed, enhance and throw error
+        // If download failed, clear the local cache so the next sync attempt starts
+        // from a clean state rather than compounding a partial download into repeated failures.
         if (downloadError) {
+            try {
+                await fs.rm(dataDir, { recursive: true, force: true });
+                await fs.mkdir(dataDir, { recursive: true });
+                serverLogger.warn('Cleared local budget cache after failed download', { dataDir });
+            } catch (cleanupErr) {
+                serverLogger.warn('Failed to clear local budget cache', {
+                    dataDir,
+                    error: cleanupErr.message,
+                });
+            }
             const enhancedError = enhanceActualApiError(downloadError, {
                 phase: 'download',
                 serverUrl: url,
@@ -528,6 +433,31 @@ async function syncBank(server, options = {}) {
             enhancedError.syncId = syncId;
             enhancedError.serverUrl = url;
             throw enhancedError;
+        }
+
+        // Workaround for @actual-app/api 26.x: when the server sets resetClock:true
+        // (first-time client or after a sync reset in the UI), downloadBudget writes
+        // db.sqlite and metadata.json to disk but does not open the budget in memory.
+        // Scanning dataDir for the matching metadata.json and calling loadBudget
+        // explicitly ensures subsequent API calls succeed regardless of resetClock state.
+        try {
+            const entries = await fs.readdir(dataDir);
+            for (const entry of entries) {
+                try {
+                    const meta = JSON.parse(
+                        await fs.readFile(`${dataDir}/${entry}/metadata.json`, 'utf8')
+                    );
+                    if (meta.groupId === syncId && meta.id) {
+                        await actual.loadBudget(meta.id);
+                        serverLogger.debug('Explicitly loaded budget after download', {
+                            localBudgetId: meta.id,
+                        });
+                        break;
+                    }
+                } catch { /* not a budget directory, skip */ }
+            }
+        } catch (loadErr) {
+            serverLogger.debug('loadBudget workaround skipped', { error: loadErr.message });
         }
 
         serverLogger.debug('Fetching accounts...');


### PR DESCRIPTION
## Summary

Fixes three bugs that together caused permanent sync failures after `@actual-app/api` 26.x was paired with a newer Actual Budget server. Closes #44.

- **Fix 1 — auto-clear corrupted cache**: after `downloadBudget` fails, the partial `db.sqlite` is deleted and `dataDir` is recreated so the next scheduled sync starts from a clean state instead of failing indefinitely
- **Fix 2 — preserve error codes**: `enhanceActualApiError` now copies `error.code` and `error.errorCode` onto the enhanced error, so sync history shows the real code instead of always `UNKNOWN`
- **Fix 4 — loadBudget workaround for `resetClock:true`**: after a successful `downloadBudget`, scans `dataDir` for the matching `metadata.json` and explicitly calls `actual.loadBudget(localId)` — required because `@actual-app/api` 26.x with `resetClock:true` writes files to disk but does not open the budget in memory
- **Dep upgrade — `@actual-app/api` 26.1.0 → 26.4.0**: the Actual Budget server had applied migration `1765518577215_multiple_dashboards.js` which did not exist in 26.1.0; without this upgrade every `loadBudget` call threw `out-of-sync-migrations` and sync failed with "No budget file is open"
- **Refactor — extract `enhanceActualApiError`**: moved to `src/lib/actualApiError.js` so tests can import it without triggering `syncService.js` script initialization

## Validation

Tested in local Docker environment (`finance-actual-budget-main:5006`):
- Confirmed bug on `main` branch (fresh download → "No budget file is open")
- Fixed branch with 26.4.0: `accountsSucceeded: 2, accountsFailed: 0`

## Test plan

- [x] 5 new test cases added (320 total, all pass)
- [x] `npm test` passes locally
- [x] Local Docker environment: full sync succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)