### PR TITLE
TEST (do not merge): #205 retarget re-test verification

### DIFF
--- a/src/__tests__/scratch205.test.js
+++ b/src/__tests__/scratch205.test.js
@@ -1,8 +1,7 @@
 // SCRATCH — verification harness for #205. Deleted before the ticket closes.
-// Deliberately failing first, to prove a red PR cannot present as green after a
-// retarget. Flipped to passing later in the same PR to prove the green path.
+// Now passing, to prove the green path re-runs correctly after a retarget.
 describe('#205 retarget re-test verification', () => {
-    it('is deliberately failing so the PR is red', () => {
-        expect('red').toBe('green');
+    it('now passes so the PR is green', () => {
+        expect('green').toBe('green');
     });
 });

--- a/src/__tests__/scratch205.test.js
+++ b/src/__tests__/scratch205.test.js
@@ -1,0 +1,8 @@
+// SCRATCH — verification harness for #205. Deleted before the ticket closes.
+// Deliberately failing first, to prove a red PR cannot present as green after a
+// retarget. Flipped to passing later in the same PR to prove the green path.
+describe('#205 retarget re-test verification', () => {
+    it('is deliberately failing so the PR is red', () => {
+        expect('red').toBe('green');
+    });
+});


### PR DESCRIPTION
Scratch PR verifying the fix for #205. Opens against `main` to simulate a Dependabot security PR, then gets retargeted to `development`.

Deliberately red first, per #205's acceptance criterion that a red PR must never present as green. **Do not merge — this will be closed and its branch deleted.**